### PR TITLE
swev-id: scikit-learn__scikit-learn-10844 | metrics: prevent int overflow in fowlkes_mallows_score denominator

### DIFF
--- a/sklearn/metrics/cluster/supervised.py
+++ b/sklearn/metrics/cluster/supervised.py
@@ -856,7 +856,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, sparse=False):
     tk = np.dot(c.data, c.data) - n_samples
     pk = np.sum(np.asarray(c.sum(axis=0)).ravel() ** 2) - n_samples
     qk = np.sum(np.asarray(c.sum(axis=1)).ravel() ** 2) - n_samples
-    return tk / np.sqrt(pk * qk) if tk != 0. else 0.
+    return (np.float64(tk) / np.sqrt(np.float64(pk) * np.float64(qk))) if tk != 0. else 0.0
 
 
 def entropy(labels):

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -274,3 +274,17 @@ def test_fowlkes_mallows_score_properties():
     # symmetric and permutation(both together)
     score_both = fowlkes_mallows_score(labels_b, (labels_a + 2) % 3)
     assert_almost_equal(score_both, expected)
+
+
+def test_fowlkes_mallows_large_int32_no_overflow():
+    # Regress overflow in denominator: ensure no RuntimeWarning and finite result
+    import warnings
+    n = 65536
+    labels = np.zeros(n, dtype=np.int32)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        score = fowlkes_mallows_score(labels, labels)
+        # No overflow warnings
+        assert not any('overflow' in str(warn.message) for warn in w), [str(warn.message) for warn in w]
+    # Perfect match should be ~1.0
+    assert_almost_equal(score, 1.0)


### PR DESCRIPTION
Fixes: #7

Summary
- Compute denominator in float64 to avoid integer overflow in  when  exceeds int32.
- Preserve existing behavior for  (returns 0.0).
- Add regression test for large int32 labels (n=65536) to ensure no overflow warnings and finite score.

Background
The current code in  does:

This triggers  when  overflows int32, leading to NaN.

Reproduction (before fix)
Minimal demonstration of the overflow mechanism in numpy (mirrors the problematic multiply):

Observed output:


Fix
Cast to float64 before multiplying inside the sqrt:

This prevents overflow and yields a finite float.

Local validation
- Added a test that builds large int32 labels (n=65536) and asserts:
  - fowlkes_mallows_score(labels, labels) is finite and ~1.0
  - no overflow RuntimeWarning is emitted.

Notes
- Base branch untouched; this PR targets  as requested.
- CI not required for this task per instructions; not triggering re-runs.
