### PR TITLE
swev-id: scikit-learn__scikit-learn-10908 fix CountVectorizer get_feature_names

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -11,6 +11,7 @@ from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
+from sklearn.exceptions import NotFittedError
 
 from sklearn.model_selection import train_test_split
 from sklearn.model_selection import cross_val_score
@@ -557,6 +558,18 @@ def test_feature_names():
 
     for idx, name in enumerate(feature_names):
         assert_equal(idx, cv.vocabulary_.get(name))
+
+
+def test_get_feature_names_with_fixed_vocab_without_fit():
+    cv = CountVectorizer(vocabulary=['b', 'a'])
+    names = cv.get_feature_names()
+    assert names == ['b', 'a']
+
+
+def test_get_feature_names_raises_without_vocab_and_fit():
+    cv = CountVectorizer()
+    with pytest.raises(NotFittedError):
+        cv.get_feature_names()
 
 
 def test_vectorizer_max_features():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -993,6 +993,8 @@ class CountVectorizer(BaseEstimator, VectorizerMixin):
 
     def get_feature_names(self):
         """Array mapping from feature integer indices to feature name"""
+        if not hasattr(self, 'vocabulary_'):
+            self._validate_vocabulary()
         self._check_vocabulary()
 
         return [t for t, i in sorted(six.iteritems(self.vocabulary_),


### PR DESCRIPTION
## Summary
- initialize the fixed vocabulary on-demand in `CountVectorizer.get_feature_names`
- add regression coverage for fixed vocabulary and unfitted cases

Fixes #10

## Testing
- python3 -m pytest sklearn/feature_extraction/tests/test_text.py *(blocked: scikit-learn requires compiled extensions; importing `sklearn` raises `ImportError: No module named 'sklearn.__check_build._check_build'` in this environment)*

## Reproduction Details
1. Instantiate `CountVectorizer(vocabulary=['b', 'a'])`
2. Call `get_feature_names()` without fitting
3. Prior to this change, a `NotFittedError` was raised even though a fixed vocabulary was provided.