### PR TITLE
feat: swev-id: scikit-learn__scikit-learn-11310 add BaseSearchCV refit_time attribute

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -17,6 +17,7 @@ from collections import Mapping, namedtuple, defaultdict, Sequence, Iterable
 from functools import partial, reduce
 from itertools import product
 import operator
+import time
 import warnings
 
 import numpy as np
@@ -405,7 +406,16 @@ class _CVScoreTuple (namedtuple('_CVScoreTuple',
 
 class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
                                       MetaEstimatorMixin)):
-    """Base class for hyper parameter search with cross-validation."""
+    """Base class for hyper parameter search with cross-validation.
+
+    Attributes
+    ----------
+    refit_time_ : float
+        Seconds used for refitting the best estimator on the complete
+        dataset when ``refit`` is truthy.
+
+        .. versionadded:: 0.20
+    """
 
     @abstractmethod
     def __init__(self, estimator, scoring=None,
@@ -766,10 +776,14 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         if self.refit:
             self.best_estimator_ = clone(base_estimator).set_params(
                 **self.best_params_)
-            if y is not None:
-                self.best_estimator_.fit(X, y, **fit_params)
-            else:
-                self.best_estimator_.fit(X, **fit_params)
+            refit_start_time = time.time()
+            try:
+                if y is not None:
+                    self.best_estimator_.fit(X, y, **fit_params)
+                else:
+                    self.best_estimator_.fit(X, **fit_params)
+            finally:
+                self.refit_time_ = time.time() - refit_start_time
 
         # Store the only scorer not as a dict for single metric evaluation
         self.scorer_ = scorers if self.multimetric_ else scorers['score']
@@ -1075,6 +1089,12 @@ class GridSearchCV(BaseSearchCV):
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
+
+    refit_time_ : float
+        Seconds used for refitting the best estimator on the whole dataset.
+        Present only if ``refit`` is truthy.
+
+        .. versionadded:: 0.20
 
     Notes
     ------
@@ -1386,6 +1406,12 @@ class RandomizedSearchCV(BaseSearchCV):
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
+
+    refit_time_ : float
+        Seconds used for refitting the best estimator on the whole dataset.
+        Present only if ``refit`` is truthy.
+
+        .. versionadded:: 0.20
 
     Notes
     -----

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -414,7 +414,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         Seconds used for refitting the best estimator on the complete
         dataset when ``refit`` is truthy.
 
-        .. versionadded:: 0.20
+        .. versionadded:: 0.22
     """
 
     @abstractmethod
@@ -440,7 +440,7 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         return self.estimator._estimator_type
 
     def score(self, X, y=None):
-        """Returns the score on the given data, if the estimator has been refit.
+        """Return the score on the given data if the estimator has been refit.
 
         This uses the score defined by ``scoring`` where provided, and the
         ``best_estimator_.score`` method otherwise.
@@ -515,7 +515,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
     def predict_log_proba(self, X):
-        """Call predict_log_proba on the estimator with the best found parameters.
+        """Call predict_log_proba on the estimator with the best found
+        parameters.
 
         Only available if ``refit=True`` and the underlying estimator supports
         ``predict_log_proba``.
@@ -532,7 +533,8 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
 
     @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
     def decision_function(self, X):
-        """Call decision_function on the estimator with the best found parameters.
+        """Call decision_function on the estimator with the best found
+        parameters.
 
         Only available if ``refit=True`` and the underlying estimator supports
         ``decision_function``.
@@ -776,14 +778,14 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
         if self.refit:
             self.best_estimator_ = clone(base_estimator).set_params(
                 **self.best_params_)
-            refit_start_time = time.time()
+            refit_start_time = time.perf_counter()
             try:
                 if y is not None:
                     self.best_estimator_.fit(X, y, **fit_params)
                 else:
                     self.best_estimator_.fit(X, **fit_params)
             finally:
-                self.refit_time_ = time.time() - refit_start_time
+                self.refit_time_ = time.perf_counter() - refit_start_time
 
         # Store the only scorer not as a dict for single metric evaluation
         self.scorer_ = scorers if self.multimetric_ else scorers['score']
@@ -1094,7 +1096,7 @@ class GridSearchCV(BaseSearchCV):
         Seconds used for refitting the best estimator on the whole dataset.
         Present only if ``refit`` is truthy.
 
-        .. versionadded:: 0.20
+        .. versionadded:: 0.22
 
     Notes
     ------
@@ -1411,7 +1413,7 @@ class RandomizedSearchCV(BaseSearchCV):
         Seconds used for refitting the best estimator on the whole dataset.
         Present only if ``refit`` is truthy.
 
-        .. versionadded:: 0.20
+        .. versionadded:: 0.22
 
     Notes
     -----

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -9,6 +9,7 @@ import pickle
 import sys
 from types import GeneratorType
 import re
+import time
 
 import numpy as np
 import scipy.sparse as sp
@@ -119,6 +120,24 @@ class LinearSVCNoScore(LinearSVC):
         raise AttributeError
 
 
+class SleepEstimator(BaseEstimator):
+    """Estimator that sleeps during fit to help measure refit time."""
+
+    def __init__(self, sleep=0.05, raise_at_n_samples=None):
+        self.sleep = sleep
+        self.raise_at_n_samples = raise_at_n_samples
+
+    def fit(self, X, y=None):
+        time.sleep(self.sleep)
+        if (self.raise_at_n_samples is not None and
+                len(X) == self.raise_at_n_samples):
+            raise RuntimeError('intentional refit failure')
+        return self
+
+    def score(self, X=None, y=None):
+        return 0.0
+
+
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
 y = np.array([1, 1, 2, 2])
 
@@ -198,6 +217,52 @@ def test_grid_search():
     # Test exception handling on scoring
     grid_search.scoring = 'sklearn'
     assert_raises(ValueError, grid_search.fit, X, y)
+
+
+def test_refit_time_present_and_positive_on_refit_true():
+    X = np.ones((12, 2))
+    y = np.zeros(12)
+    grid = GridSearchCV(SleepEstimator(), {'sleep': [0.05, 0.1]}, cv=3,
+                        refit=True)
+    grid.fit(X, y)
+    assert hasattr(grid, 'refit_time_')
+    assert grid.refit_time_ >= 0.0
+    best_sleep = grid.best_estimator_.sleep
+    assert grid.refit_time_ == pytest.approx(best_sleep, rel=0.5, abs=0.01)
+
+
+def test_refit_time_not_set_when_refit_false():
+    X = np.ones((12, 2))
+    y = np.zeros(12)
+    grid = GridSearchCV(SleepEstimator(), {'sleep': [0.05, 0.1]}, cv=3,
+                        refit=False)
+    grid.fit(X, y)
+    assert not hasattr(grid, 'refit_time_')
+
+
+def test_refit_time_measures_only_refit_phase():
+    X = np.ones((15, 2))
+    y = np.zeros(15)
+    grid = GridSearchCV(SleepEstimator(), {'sleep': [0.05, 0.08]}, cv=5)
+    grid.fit(X, y)
+    total_cv_time = (grid.cv_results_['mean_fit_time'][grid.best_index_] *
+                     grid.n_splits_)
+    assert grid.refit_time_ < total_cv_time
+    assert grid.refit_time_ == pytest.approx(grid.best_estimator_.sleep,
+                                             rel=0.5, abs=0.01)
+
+
+def test_refit_time_set_on_refit_exception():
+    X = np.ones((12, 2))
+    y = np.zeros(12)
+    estimator = SleepEstimator(sleep=0.05, raise_at_n_samples=len(X))
+    grid = GridSearchCV(estimator, {'sleep': [0.05]}, cv=3)
+    with pytest.raises(RuntimeError):
+        grid.fit(X, y)
+    assert hasattr(grid, 'refit_time_')
+    assert grid.refit_time_ >= 0.0
+    assert grid.refit_time_ == pytest.approx(estimator.sleep, rel=0.5,
+                                             abs=0.01)
 
 
 def check_hyperparameter_searcher_with_fit_params(klass, **klass_kwargs):


### PR DESCRIPTION
## Summary
- measure final refit time in BaseSearchCV and expose refit_time_
- document refit_time_ in BaseSearchCV/GridSearchCV/RandomizedSearchCV
- add SleepEstimator-based tests for refit timing, refit=False, and failure cases

## Testing
- . .venv/bin/activate && pytest sklearn/model_selection/tests/test_search.py -k refit_time *(fails: compiled extensions missing; see ImportError for sklearn.__check_build)*

Closes #9