### PR TITLE
swev-id: scikit-learn__scikit-learn-12973 — LassoLarsIC.fit(copy_X=None) precedence fix

### DIFF
--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -113,6 +113,11 @@ Support for Python 3.4 and below has been officially dropped.
   :class:`linear_model.MultiTaskLasso` which were breaking when
   ``warm_start = True``. :issue:`12360` by :user:`Aakanksha Joshi <joaak>`.
 
+- |Fix| Ensured :class:`linear_model.LassoLarsIC.fit` defers to the
+  estimator's ``copy_X`` attribute when ``copy_X`` is not provided, so that
+  preprocessing and :func:`linear_model.lars_path` receive the same value.
+  :issue:`20` by :user:`Casey Brooks <caseybrooks>`.
+
 - |API| :func:`linear_model.logistic_regression_path` is deprecated
   in version 0.21 and will be removed in version 0.23.
   :issue:`12821` by :user:`Nicolas Hug <NicolasHug>`.

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -759,7 +759,9 @@ class LassoLars(Lars):
         the tolerance of the optimization.
 
     copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten.
+        If True, X will be copied; else, it may be overwritten. This value is
+        used as the default for ``fit``; passing ``copy_X`` to ``fit`` takes
+        precedence over this attribute.
 
     fit_path : boolean
         If ``True`` the full path is stored in the ``coef_path_`` attribute.
@@ -1479,7 +1481,7 @@ class LassoLarsIC(LassoLars):
         self.eps = eps
         self.fit_path = True
 
-    def fit(self, X, y, copy_X=True):
+    def fit(self, X, y, copy_X=None):
         """Fit the model using X, y as training data.
 
         Parameters
@@ -1490,8 +1492,10 @@ class LassoLarsIC(LassoLars):
         y : array-like, shape (n_samples,)
             target values. Will be cast to X's dtype if necessary
 
-        copy_X : boolean, optional, default True
-            If ``True``, X will be copied; else, it may be overwritten.
+        copy_X : bool or None, optional, default None
+            Whether the design matrix should be copied. If ``True``, ``X``
+            will be copied; else, it may be overwritten. If ``None``, the
+            estimator's ``copy_X`` attribute is used.
 
         Returns
         -------
@@ -1500,14 +1504,17 @@ class LassoLarsIC(LassoLars):
         """
         X, y = check_X_y(X, y, y_numeric=True)
 
+        effective_copy_X = self.copy_X if copy_X is None else copy_X
+
         X, y, Xmean, ymean, Xstd = LinearModel._preprocess_data(
-            X, y, self.fit_intercept, self.normalize, self.copy_X)
+            X, y, self.fit_intercept, self.normalize, effective_copy_X)
         max_iter = self.max_iter
 
         Gram = self.precompute
 
         alphas_, active_, coef_path_, self.n_iter_ = lars_path(
-            X, y, Gram=Gram, copy_X=copy_X, copy_Gram=True, alpha_min=0.0,
+            X, y, Gram=Gram, copy_X=effective_copy_X, copy_Gram=True,
+            alpha_min=0.0,
             method='lasso', verbose=self.verbose, max_iter=max_iter,
             eps=self.eps, return_n_iter=True, positive=self.positive)
 

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -759,9 +759,7 @@ class LassoLars(Lars):
         the tolerance of the optimization.
 
     copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten. This
-        attribute provides the default value used by :meth:`fit` when its
-        ``copy_X`` parameter is ``None``.
+        If True, X will be copied; else, it may be overwritten.
 
     fit_path : boolean
         If ``True`` the full path is stored in the ``coef_path_`` attribute.
@@ -1403,7 +1401,9 @@ class LassoLarsIC(LassoLars):
         the tolerance of the optimization.
 
     copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten.
+        If True, X will be copied; else, it may be overwritten. This
+        attribute provides the default value used by :meth:`fit` when its
+        ``copy_X`` parameter is ``None``.
 
     positive : boolean (default=False)
         Restrict coefficients to be >= 0. Be aware that you might want to

--- a/sklearn/linear_model/least_angle.py
+++ b/sklearn/linear_model/least_angle.py
@@ -759,9 +759,9 @@ class LassoLars(Lars):
         the tolerance of the optimization.
 
     copy_X : boolean, optional, default True
-        If True, X will be copied; else, it may be overwritten. This value is
-        used as the default for ``fit``; passing ``copy_X`` to ``fit`` takes
-        precedence over this attribute.
+        If True, X will be copied; else, it may be overwritten. This
+        attribute provides the default value used by :meth:`fit` when its
+        ``copy_X`` parameter is ``None``.
 
     fit_path : boolean
         If ``True`` the full path is stored in the ``coef_path_`` attribute.

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy import linalg
 
 import pytest
+from unittest.mock import patch
 
 from sklearn.model_selection import train_test_split
 from sklearn.utils.testing import assert_equal
@@ -686,3 +687,42 @@ def test_lasso_lars_vs_R_implementation():
 
     assert_array_almost_equal(r2, skl_betas2, decimal=12)
     ###########################################################################
+
+
+class TestLassoLarsICCopyX(object):
+
+    def _make_data(self):
+        X = np.arange(15, dtype=np.float64).reshape(5, 3)
+        y = np.arange(5, dtype=np.float64)
+        return X, y
+
+    def _fit_and_assert(self, estimator, fit_kwargs, expected_copy):
+        X, y = self._make_data()
+        with patch('sklearn.linear_model.least_angle.LinearModel._preprocess_data') as preprocess_mock, \
+                patch('sklearn.linear_model.least_angle.lars_path') as lars_path_mock:
+            preprocess_mock.return_value = (
+                X, y, np.zeros(X.shape[1]), 0., np.ones(X.shape[1]))
+            lars_path_mock.return_value = (
+                np.array([1.0]),
+                np.array([0], dtype=np.int),
+                np.zeros((X.shape[1], 1)),
+                1)
+
+            estimator.fit(X, y, **fit_kwargs)
+            assert preprocess_mock.call_args[0][-1] == expected_copy
+            assert lars_path_mock.call_args[1]['copy_X'] == expected_copy
+
+    def test_respects_estimator_copy_false(self):
+        estimator = linear_model.LassoLarsIC(copy_X=False, precompute=False)
+        self._fit_and_assert(estimator, {}, False)
+
+    def test_override_to_true_and_reverse(self):
+        estimator = linear_model.LassoLarsIC(copy_X=False, precompute=False)
+        self._fit_and_assert(estimator, {'copy_X': True}, True)
+
+        estimator = linear_model.LassoLarsIC(copy_X=True, precompute=False)
+        self._fit_and_assert(estimator, {'copy_X': False}, False)
+
+    def test_default_none_resolves_to_true(self):
+        estimator = linear_model.LassoLarsIC(precompute=False)
+        self._fit_and_assert(estimator, {}, True)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -704,7 +704,7 @@ class TestLassoLarsICCopyX(object):
                 X, y, np.zeros(X.shape[1]), 0., np.ones(X.shape[1]))
             lars_path_mock.return_value = (
                 np.array([1.0]),
-                np.array([0], dtype=np.int),
+                np.array([0], dtype=np.int64),
                 np.zeros((X.shape[1], 1)),
                 1)
 


### PR DESCRIPTION
## Summary
- ensure LassoLarsIC.fit accepts copy_X=None and defers to estimator default
- route the effective copy_X through preprocessing and lars_path
- document bug fix and add targeted regression tests

## Testing
- pytest -q -k LassoLarsICCopyX  (fails: missing compiled sklearn extensions in container)

Resolves #20.