### PR TITLE
swev-id: scikit-learn__scikit-learn-13439 implement Pipeline __len__

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -199,6 +199,10 @@ class Pipeline(_BaseComposition):
             if trans is not None and trans != 'passthrough':
                 yield idx, name, trans
 
+    def __len__(self):
+        """Return the number of steps in the pipeline."""
+        return len(self.steps)
+
     def __getitem__(self, ind):
         """Returns a sub-pipeline or a single esimtator in the pipeline
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -529,6 +529,35 @@ def test_pipeline_fit_transform():
     assert_array_almost_equal(X_trans, X_trans2)
 
 
+def test_pipeline_len():
+    steps = [('transf', Transf()), ('clf', FitParamT())]
+    pipe = Pipeline(steps)
+    assert len(pipe) == len(steps)
+
+    passthrough_steps = [('transf', Transf()), ('final', 'passthrough')]
+    pipe_passthrough = Pipeline(passthrough_steps)
+    assert len(pipe_passthrough) == len(passthrough_steps)
+
+    none_steps = [('transf', Transf()), ('final', None)]
+    pipe_none = Pipeline(none_steps)
+    assert len(pipe_none) == len(none_steps)
+
+
+def test_pipeline_slice_with_len():
+    steps = [
+        ('transf1', Transf()),
+        ('transf2', Transf()),
+        ('clf', FitParamT())
+    ]
+    pipe = Pipeline(steps)
+
+    pipe_all = pipe[:len(pipe)]
+
+    assert isinstance(pipe_all, Pipeline)
+    assert pipe_all.steps == steps
+    assert len(pipe_all) == len(pipe)
+
+
 def test_pipeline_slice():
     pipe = Pipeline([('transf1', Transf()),
                      ('transf2', Transf()),


### PR DESCRIPTION
## Summary
- addresses #28 by adding Pipeline.__len__ so len(pipe) works with sequence-style helpers
- adds regression tests for len() with passthrough/None final estimators and slicing via pipe[:len(pipe)]

## Observed failure
After building scikit-learn in editable mode, reproducing the issue with the snippet from #28 fails:

```bash
python - <<'PY'
from sklearn import svm
from sklearn.datasets import samples_generator
from sklearn.feature_selection import SelectKBest
from sklearn.feature_selection import f_regression
from sklearn.pipeline import Pipeline

X, y = samples_generator.make_classification(
    n_informative=5, n_redundant=0, random_state=42)

anova_filter = SelectKBest(f_regression, k=5)
clf = svm.SVC(kernel='linear')
pipe = Pipeline([('anova', anova_filter), ('svc', clf)])

print(len(pipe))
PY
```

```
Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
TypeError: object of type 'Pipeline' has no len()
```

## Testing
- `pytest sklearn/tests/test_pipeline.py -k len` (2 passed)
- `flake8 sklearn/pipeline.py sklearn/tests/test_pipeline.py`
