### PR TITLE
FIX: make HuberRegressor accept boolean X

### DIFF
--- a/sklearn/linear_model/huber.py
+++ b/sklearn/linear_model/huber.py
@@ -11,6 +11,7 @@ from ..utils import check_X_y
 from ..utils import check_consistent_length
 from ..utils import axis0_safe_slice
 from ..utils.extmath import safe_sparse_dot
+from ..utils.validation import FLOAT_DTYPES
 
 
 def _huber_loss_and_gradient(w, X, y, epsilon, alpha, sample_weight=None):
@@ -251,7 +252,8 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         self : object
         """
         X, y = check_X_y(
-            X, y, copy=False, accept_sparse=['csr'], y_numeric=True)
+            X, y, copy=False, accept_sparse=['csr'],
+            y_numeric=True, dtype=FLOAT_DTYPES)
         if sample_weight is not None:
             sample_weight = np.array(sample_weight)
             check_consistent_length(y, sample_weight)

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -199,3 +199,40 @@ def test_huber_better_r2_score():
 
     # The huber model should also fit poorly on the outliers.
     assert_greater(ridge_outlier_score, huber_outlier_score)
+
+
+def test_huber_bool_X_dense_cast_and_fit():
+    X, y = make_regression(n_samples=40, n_features=5, noise=2.0,
+                           random_state=0)
+    X_bool = X > 0
+    X_float = X_bool.astype(np.float64)
+
+    huber_bool = HuberRegressor()
+    huber_bool.fit(X_bool, y)
+
+    huber_float = HuberRegressor()
+    huber_float.fit(X_float, y)
+
+    assert_array_almost_equal(huber_bool.coef_, huber_float.coef_)
+    assert_almost_equal(huber_bool.intercept_, huber_float.intercept_)
+    assert_array_almost_equal(huber_bool.predict(X_bool),
+                              huber_float.predict(X_float))
+
+
+def test_huber_bool_X_sparse_cast_and_fit():
+    X, y = make_regression(n_samples=40, n_features=5, noise=2.0,
+                           random_state=0)
+    X_bool = X > 0
+    X_sparse_bool = sparse.csr_matrix(X_bool)
+    X_sparse_float = X_sparse_bool.astype(np.float64)
+
+    huber_bool = HuberRegressor()
+    huber_bool.fit(X_sparse_bool, y)
+
+    huber_float = HuberRegressor()
+    huber_float.fit(X_sparse_float, y)
+
+    assert_array_almost_equal(huber_bool.coef_, huber_float.coef_)
+    assert_almost_equal(huber_bool.intercept_, huber_float.intercept_)
+    assert_array_almost_equal(huber_bool.predict(X_sparse_bool),
+                              huber_float.predict(X_sparse_float))


### PR DESCRIPTION
## Summary
- coerce inputs to accepted FLOAT_DTYPES via `check_X_y` to avoid boolean negation errors in `_huber_loss_and_gradient`
- add dense and sparse regression tests that compare boolean matrices with their float-cast counterparts
- capture the legacy failure stack trace for reference

## Pre-fix failure
```pytb
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "sklearn/linear_model/huber.py", line 284, in fit
    parameters, f, dict_ = optimize.fmin_l_bfgs_b(
  File "scipy/optimize/lbfgsb.py", line 197, in fmin_l_bfgs_b
    res = _minimize_lbfgsb(fun, x0, args=args, jac=jac, bounds=bounds,
  File "scipy/optimize/lbfgsb.py", line 306, in _minimize_lbfgsb
    sf = _prepare_scalar_function(fun, x0, jac=jac, args=args, epsilon=eps,
  File "scipy/optimize/optimize.py", line 261, in _prepare_scalar_function
    sf = ScalarFunction(fun, x0, args, grad, hess,
  File "scipy/optimize/_differentiable_functions.py", line 140, in __init__
    self._update_fun()
  File "scipy/optimize/_differentiable_functions.py", line 233, in _update_fun
    self._update_fun_impl()
  File "scipy/optimize/_differentiable_functions.py", line 137, in update_fun
    self.f = fun_wrapped(self.x)
  File "scipy/optimize/optimize.py", line 74, in __call__
    self._compute_if_needed(x, *args)
  File "scipy/optimize/optimize.py", line 68, in _compute_if_needed
    fg = self.fun(x, *args)
  File "sklearn/linear_model/huber.py", line 93, in _huber_loss_and_gradient
    X_non_outliers = -axis0_safe_slice(X, ~outliers_mask, n_non_outliers)
TypeError: The numpy boolean negative, the `-` operator, is not supported, use the `~` operator or the logical_not function instead.
```

## Testing
- pytest -q sklearn/linear_model/tests/test_huber.py --maxfail=1
- git diff -U0 | flake8 --diff

Fixes #32949