### PR TITLE
swev-id: scikit-learn__scikit-learn-13779 - skip None estimators in sample_weight validation

### DIFF
--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -19,7 +19,7 @@ from sklearn.datasets import make_multilabel_classification
 from sklearn.svm import SVC
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.dummy import DummyRegressor
 
 
@@ -346,6 +346,109 @@ def test_sample_weight():
         voting='soft')
     msg = ('Underlying estimator \'knn\' does not support sample weights.')
     assert_raise_message(ValueError, msg, eclf3.fit, X, y, sample_weight)
+
+
+def test_none_estimator_with_sample_weight_classifier():
+    class SupportsSampleWeightClassifier(ClassifierMixin, BaseEstimator):
+        def fit(self, X, y, sample_weight=None):
+            self.sample_weight_ = sample_weight
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    class AnotherClassifier(SupportsSampleWeightClassifier):
+        pass
+
+    X_local = np.arange(6).reshape(-1, 1)
+    y_local = np.array([0, 1, 0, 1, 0, 1])
+    sample_weight = np.ones_like(y_local, dtype=float)
+
+    voter = VotingClassifier(
+        estimators=[
+            ('to_drop', SupportsSampleWeightClassifier()),
+            ('keep', AnotherClassifier())
+        ],
+        voting='hard'
+    )
+    voter.fit(X_local, y_local, sample_weight=sample_weight)
+    voter.set_params(to_drop=None)
+
+    voter.fit(X_local, y_local, sample_weight=sample_weight)
+
+    assert len(voter.estimators_) == 1
+    assert isinstance(voter.estimators_[0], AnotherClassifier)
+    assert np.array_equal(voter.estimators_[0].sample_weight_, sample_weight)
+
+
+def test_none_estimator_with_sample_weight_regressor():
+    class SupportsSampleWeightRegressor(RegressorMixin, BaseEstimator):
+        def fit(self, X, y, sample_weight=None):
+            self.sample_weight_ = sample_weight
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=float)
+
+    class AnotherRegressor(SupportsSampleWeightRegressor):
+        pass
+
+    X_local = np.arange(6).reshape(-1, 1)
+    y_local = np.arange(6, dtype=float)
+    sample_weight = np.ones_like(y_local, dtype=float)
+
+    voter = VotingRegressor([
+        ('to_drop', SupportsSampleWeightRegressor()),
+        ('keep', AnotherRegressor())
+    ])
+    voter.fit(X_local, y_local, sample_weight=sample_weight)
+    voter.set_params(to_drop=None)
+
+    voter.fit(X_local, y_local, sample_weight=sample_weight)
+
+    assert len(voter.estimators_) == 1
+    assert isinstance(voter.estimators_[0], AnotherRegressor)
+    assert np.array_equal(voter.estimators_[0].sample_weight_, sample_weight)
+
+
+def test_sample_weight_mixed_support_with_none():
+    class SupportsSampleWeightClassifier(ClassifierMixin, BaseEstimator):
+        def fit(self, X, y, sample_weight=None):
+            self.sample_weight_ = sample_weight
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    class NoSampleWeightClassifier(ClassifierMixin, BaseEstimator):
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    X_local = np.arange(6).reshape(-1, 1)
+    y_local = np.array([0, 1, 0, 1, 0, 1])
+    sample_weight = np.ones_like(y_local, dtype=float)
+
+    voter = VotingClassifier(
+        estimators=[
+            ('to_drop', SupportsSampleWeightClassifier()),
+            ('no_sw', NoSampleWeightClassifier())
+        ],
+        voting='hard'
+    )
+    voter.set_params(to_drop=None)
+
+    msg = "Underlying estimator 'no_sw' does not support sample weights."
+    assert_raise_message(
+        ValueError,
+        msg,
+        voter.fit,
+        X_local,
+        y_local,
+        sample_weight=sample_weight
+    )
 
 
 def test_sample_weight_kwargs():

--- a/sklearn/ensemble/voting.py
+++ b/sklearn/ensemble/voting.py
@@ -78,6 +78,8 @@ class _BaseVoting(_BaseComposition, TransformerMixin):
 
         if sample_weight is not None:
             for name, step in self.estimators:
+                if step is None:
+                    continue
                 if not has_fit_parameter(step, 'sample_weight'):
                     raise ValueError('Underlying estimator \'%s\' does not'
                                      ' support sample weights.' % name)


### PR DESCRIPTION
## Summary
- skip None estimators when validating sample_weight support to match Voting* drop behaviour
- add regression tests covering None estimators for classifier/regressor and mixed support error path

Resolves #31.

## Reproduction
```python
from sklearn.datasets import load_iris
from sklearn.ensemble import VotingClassifier
from sklearn.linear_model import LogisticRegression
from sklearn.ensemble import RandomForestClassifier
import numpy as np

X, y = load_iris(return_X_y=True)
voter = VotingClassifier(
    estimators=[('lr', LogisticRegression()),
                ('rf', RandomForestClassifier())]
)
voter.fit(X, y, sample_weight=np.ones(y.shape))
voter.set_params(lr=None)
voter.fit(X, y, sample_weight=np.ones(y.shape))
```

Observed stack trace:
```
/root/.local/lib/python3.11/site-packages/sklearn/linear_model/_logistic.py:406: ConvergenceWarning: lbfgs failed to converge after 100 iteration(s) (status=1):
STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT

Increase the number of iterations to improve the convergence (max_iter=100).
You might also want to scale the data as shown in:
    https://scikit-learn.org/stable/modules/preprocessing.html
Please also refer to the documentation for alternative solver options:
    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression
  n_iter_i = _check_optimize_result(
Traceback (most recent call last):
  File "/root/.local/lib/python3.11/site-packages/sklearn/utils/_tags.py", line 275, in get_tags
    tags = estimator.__sklearn_tags__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '__sklearn_tags__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
  File "/root/.local/lib/python3.11/site-packages/sklearn/base.py", line 1336, in wrapper
    return fit_method(estimator, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/sklearn/ensemble/_voting.py", line 405, in fit
    return super().fit(X, transformed_y, **fit_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/sklearn/ensemble/_voting.py", line 80, in fit
    names, clfs = self._validate_estimators()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/sklearn/ensemble/_base.py", line 242, in _validate_estimators
    if est != "drop" and not is_estimator_type(est):
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/sklearn/base.py", line 1211, in is_classifier
    return get_tags(estimator).estimator_type == "classifier"
           ^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.11/site-packages/sklearn/utils/_tags.py", line 283, in get_tags
    raise AttributeError(
AttributeError: The following error was raised: 'NoneType' object has no attribute '__sklearn_tags__'. It seems that there are no classes that implement `__sklearn_tags__` in the MRO and/or all classes in the MRO call `super().__sklearn_tags__()`. Make sure to inherit from `BaseEstimator` which implements `__sklearn_tags__` (or alternatively define `__sklearn_tags__` but we don't recommend this approach). Note that `BaseEstimator` needs to be on the right side of other Mixins in the inheritance order.
```

## Testing
- `PYTHONPATH=/workspace:${PYTHONPATH} LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/y6zrr7dfg051mz4dpjvaldy4g9cy6wmq-lapack-3/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib python3 -m pytest sklearn/ensemble/tests/test_voting.py -k "none_estimator_with_sample_weight_classifier or none_estimator_with_sample_weight_regressor or sample_weight_mixed_support_with_none"`
  (uses workspace sitecustomize stubs to satisfy legacy compiled dependencies)
