### PR TITLE
fix: include joblib in show_versions (swev-id: scikit-learn__scikit-learn-14141)

### DIFF
--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -48,6 +48,7 @@ def _get_deps_info():
         "Cython",
         "pandas",
         "matplotlib",
+        "joblib",
     ]
 
     def get_version(module):

--- a/sklearn/utils/tests/test_show_versions.py
+++ b/sklearn/utils/tests/test_show_versions.py
@@ -21,6 +21,7 @@ def test_get_deps_info():
     assert 'numpy' in deps_info
     assert 'scipy' in deps_info
     assert 'Cython' in deps_info
+    assert 'joblib' in deps_info
     assert 'pandas' in deps_info
     assert 'matplotlib' in deps_info
 
@@ -30,4 +31,5 @@ def test_show_versions_with_blas(capsys):
     out, err = capsys.readouterr()
     assert 'python' in out
     assert 'numpy' in out
+    assert 'joblib' in out
     assert 'BLAS' in out


### PR DESCRIPTION
## Summary
- add `joblib` to the dependency summary returned by `sklearn.utils._show_versions._get_deps_info`
- align show_versions tests to expect the new entry in both the dict and the printed report

## Testing
- `PYTHONPATH=$(pwd)/pyoverride LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/y6zrr7dfg051mz4dpjvaldy4g9cy6wmq-lapack-3/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib python3 -m pytest sklearn/utils/tests/test_show_versions.py`
  - 3 passed, 12 warnings
- `python3 -m flake8 sklearn/utils/_show_versions.py sklearn/utils/tests/test_show_versions.py`
  - lint clean

## Reproduction steps
Because the repository is not built in this environment, the commands below use a small `sitecustomize.py` shim so that `sklearn.show_versions()` can run without compiled extensions.

```bash
cat <<'PY' > pyoverride/sitecustomize.py
import builtins
import importlib.util
import os
import pathlib
import sys
import types

os.environ.setdefault('SETUPTOOLS_USE_DISTUTILS', 'stdlib')
repo_root = pathlib.Path(__file__).resolve().parent.parent
if str(repo_root) not in sys.path:
    sys.path.insert(0, str(repo_root))

builtins.__SKLEARN_SETUP__ = True
import sklearn as _sklearn  # noqa: E402

_config_spec = importlib.util.spec_from_file_location(
    'sklearn._config', repo_root / 'sklearn' / '_config.py')
_config_module = importlib.util.module_from_spec(_config_spec)
_config_spec.loader.exec_module(_config_module)

_sklearn.get_config = _config_module.get_config
_sklearn.set_config = _config_module.set_config
_sklearn.config_context = _config_module.config_context

show_versions_spec = importlib.util.spec_from_file_location(
    'sklearn.utils._show_versions', repo_root / 'sklearn' / 'utils' / '_show_versions.py')
show_versions_module = importlib.util.module_from_spec(show_versions_spec)
show_versions_spec.loader.exec_module(show_versions_module)

utils_module = types.ModuleType('sklearn.utils')
utils_module.__path__ = [str(repo_root / 'sklearn' / 'utils')]
utils_module._show_versions = show_versions_module
sys.modules['sklearn.utils'] = utils_module
sys.modules['sklearn.utils._show_versions'] = show_versions_module

_sklearn.show_versions = show_versions_module.show_versions
PY

export PYTHONPATH=$(pwd)/pyoverride
export LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/y6zrr7dfg051mz4dpjvaldy4g9cy6wmq-lapack-3/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib
```

### Before (scikit-learn__scikit-learn-14141)
```bash
git checkout scikit-learn__scikit-learn-14141
python3 -c "import sklearn; sklearn.show_versions()" | sed -n '13,24p'
```
```
Python deps:
       pip: None
setuptools: 80.9.0
   sklearn: 0.22.dev0
     numpy: 2.4.0
     scipy: 1.16.3
    Cython: 3.2.3
    pandas: None
matplotlib: None
```

### After (noa/issue-37)
```bash
git checkout noa/issue-37
python3 -c "import sklearn; sklearn.show_versions()" | sed -n '13,25p'
```
```
Python deps:
       pip: None
setuptools: 80.9.0
   sklearn: 0.22.dev0
     numpy: 2.4.0
     scipy: 1.16.3
    Cython: 3.2.3
    pandas: None
matplotlib: None
    joblib: 1.5.3
```

Observed omission: `joblib` was not reported under "Python deps" before this change.

Related issue: #37
