### PR TITLE
Fix export_text single-feature handling (swev-id: scikit-learn__scikit-learn-14053)

### DIFF
--- a/sklearn/tree/export.py
+++ b/sklearn/tree/export.py
@@ -889,10 +889,11 @@ def export_text(decision_tree, feature_names=None, max_depth=10,
     else:
         value_fmt = "{}{} value: {}\n"
 
-    if feature_names:
-        feature_names_ = [feature_names[i] for i in tree_.feature]
+    if feature_names is not None:
+        feature_names_ = list(feature_names)
     else:
-        feature_names_ = ["feature_{}".format(i) for i in tree_.feature]
+        feature_names_ = ["feature_{}".format(i)
+                          for i in range(tree_.n_features)]
 
     export_text.report = ""
 
@@ -928,7 +929,8 @@ def export_text(decision_tree, feature_names=None, max_depth=10,
             info_fmt_right = info_fmt
 
             if tree_.feature[node] != _tree.TREE_UNDEFINED:
-                name = feature_names_[node]
+                feature_index = tree_.feature[node]
+                name = feature_names_[feature_index]
                 threshold = tree_.threshold[node]
                 threshold = "{1:.{0}f}".format(decimals, threshold)
                 export_text.report += right_child_fmt.format(indent,

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -397,6 +397,26 @@ def test_export_text():
     assert export_text(reg, decimals=1, show_weights=True) == expected_report
 
 
+def test_export_text_single_feature_with_names():
+    X_single = [[-2], [-1], [-1], [1], [1], [2]]
+    y_single = [-1, -1, -1, 1, 1, 1]
+    clf = DecisionTreeClassifier(random_state=0)
+    clf.fit(X_single, y_single)
+
+    report = export_text(clf, feature_names=['single'])
+    assert_in('single <=', report)
+
+
+def test_export_text_single_feature_auto_names():
+    X_single = [[-2], [-1], [-1], [1], [1], [2]]
+    y_single = [-1, -1, -1, 1, 1, 1]
+    clf = DecisionTreeClassifier(random_state=0)
+    clf.fit(X_single, y_single)
+
+    report = export_text(clf)
+    assert_in('feature_0', report)
+
+
 def test_plot_tree_entropy(pyplot):
     # mostly smoke tests
     # Check correctness of export_graphviz for criterion = entropy


### PR DESCRIPTION
## Summary
- ensure export_text resolves feature names by index instead of node ids
- avoid TREE_UNDEFINED indices by building names from n_features length
- add regression coverage for single-feature classifiers with and without provided names

## Reproduction
```python
from sklearn.tree import DecisionTreeClassifier
from sklearn.tree.export import export_text
from sklearn.datasets import load_iris

X, y = load_iris(return_X_y=True)
X = X[:, 0].reshape(-1, 1)

tree = DecisionTreeClassifier()
tree.fit(X, y)
tree_text = export_text(tree, feature_names=['sepal_length'])
print(tree_text)
```

**Observed failure (pre-fix)**
```
Traceback (most recent call last):
  File "<stdin>", line 18, in <module>
  File "/workspace/tmp_old_export.py", line 893, in export_text
    feature_names_ = [feature_names[i] for i in tree_.feature]
  File "/workspace/tmp_old_export.py", line 893, in <listcomp>
    feature_names_ = [feature_names[i] for i in tree_.feature]
IndexError: list index out of range
```

## Testing
- PYTHONPATH=/workspace/scikit-learn LD_LIBRARY_PATH=/workspace/sklearn-py38/lib:$LD_LIBRARY_PATH /workspace/sklearn-py38/bin/flake8 sklearn/tree/export.py sklearn/tree/tests/test_export.py
- PYTHONPATH=/workspace/sklearn-py38/lib/python3.8/site-packages LD_LIBRARY_PATH=/workspace/sklearn-py38/lib:$LD_LIBRARY_PATH /workspace/sklearn-py38/bin/pytest /workspace/tmp_tests/test_export.py -k export_text

Fixes #34
