### PR TITLE
Fix HistGradientBoostingClassifier early stopping with string labels (swev-id: scikit-learn__scikit-learn-14710)}

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -426,13 +426,26 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
         Scores are computed on validation data or on training data.
         """
+        y_small_train_for_score = y_small_train
+        y_val_for_score = y_val
+
+        if is_classifier(self):
+            y_small_train_for_score = self.classes_[
+                y_small_train.astype(np.intp, copy=False)
+            ]
+
+            if y_val is not None:
+                y_val_for_score = self.classes_[
+                    y_val.astype(np.intp, copy=False)
+                ]
+
         self.train_score_.append(
-            self.scorer_(self, X_binned_small_train, y_small_train)
+            self.scorer_(self, X_binned_small_train, y_small_train_for_score)
         )
 
         if self._use_validation_data:
             self.validation_score_.append(
-                self.scorer_(self, X_binned_val, y_val)
+                self.scorer_(self, X_binned_val, y_val_for_score)
             )
             return self._should_stop(self.validation_score_)
         else:

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -132,6 +132,48 @@ def test_early_stopping_classification(data, scoring, validation_fraction,
         assert gb.n_iter_ == max_iter
 
 
+def test_early_stopping_string_labels_binary():
+    X, y_numeric = make_classification(n_samples=80, n_features=5,
+                                       n_informative=4, n_redundant=0,
+                                       n_classes=2, random_state=0)
+    string_labels = np.array(['class_a', 'class_b'], dtype=object)
+    y = string_labels[y_numeric]
+
+    gb = HistGradientBoostingClassifier(
+        scoring='accuracy',
+        validation_fraction=0.2,
+        n_iter_no_change=5,
+        max_iter=30,
+        random_state=0,
+    )
+    gb.fit(X, y)
+
+    assert set(gb.classes_) == {'class_a', 'class_b'}
+    assert len(gb.validation_score_) > 0
+
+
+def test_early_stopping_string_labels_multiclass():
+    X, y_numeric = make_classification(n_samples=90, n_features=6,
+                                       n_informative=5, n_redundant=0,
+                                       n_repeated=0, n_classes=3,
+                                       n_clusters_per_class=1,
+                                       random_state=0)
+    string_labels = np.array(['class_a', 'class_b', 'class_c'], dtype=object)
+    y = string_labels[y_numeric]
+
+    gb = HistGradientBoostingClassifier(
+        scoring='accuracy',
+        validation_fraction=None,
+        n_iter_no_change=5,
+        max_iter=30,
+        random_state=0,
+    )
+    gb.fit(X, y)
+
+    assert set(gb.classes_) == {'class_a', 'class_b', 'class_c'}
+    assert len(gb.train_score_) > 0
+
+
 @pytest.mark.parametrize(
     'scores, n_iter_no_change, tol, stopping',
     [


### PR DESCRIPTION
#14710

## Summary
- ensure early stopping scorer uses decoded class labels before invoking scorers
- add binary and multiclass regression tests covering string label training and validation paths
- retain existing training/validation score bookkeeping

## Testing
- `pytest`
- `flake8 sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py`

## Reproduction
```python
import numpy as np
from sklearn.datasets import make_classification
from sklearn.ensemble import HistGradientBoostingClassifier

X, y = make_classification(random_state=0)
y = np.where(y == 0, 'class_a', 'class_b')

HistGradientBoostingClassifier(
    max_iter=30,
    n_iter_no_change=5,
    scoring='accuracy',
    validation_fraction=0.2,
    random_state=0,
).fit(X, y)
```

```
Traceback (most recent call last):
  ...
  File "sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py", line 437, in _maybe_do_early_stopping
    self.scorer_(self, X_binned_val, y_val)
  File "sklearn/metrics/_scorer.py", line 88, in __call__
    return self._score(
  File "sklearn/metrics/_scorer.py", line 252, in _score
    return scorer(y_true, y_pred, sample_weight=sample_weight)
  File "sklearn/metrics/_classification.py", line 1871, in accuracy_score
    y_type, y_true, y_pred = _check_targets(y_true, y_pred)
  File "sklearn/metrics/_classification.py", line 101, in _check_targets
    raise TypeError("< not supported between instances of str and float")
TypeError: '<' not supported between instances of 'str' and 'float'
```

Fixes #47