### PR TITLE
Fix sparse SVR empty support vectors (swev-id: scikit-learn__scikit-learn-14894)

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -286,12 +286,15 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             n_class = 1
         n_SV = self.support_vectors_.shape[0]
 
-        dual_coef_indices = np.tile(np.arange(n_SV), n_class)
-        dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,
-                                     dual_coef_indices.size / n_class)
-        self.dual_coef_ = sp.csr_matrix(
-            (dual_coef_data, dual_coef_indices, dual_coef_indptr),
-            (n_class, n_SV))
+        if n_SV == 0 or dual_coef_data.size == 0:
+            self.dual_coef_ = sp.csr_matrix((n_class, 0), dtype=np.float64)
+        else:
+            dual_coef_indices = np.tile(np.arange(n_SV), n_class)
+            dual_coef_indptr = np.arange(0, dual_coef_indices.size + 1,
+                                         dual_coef_indices.size / n_class)
+            self.dual_coef_ = sp.csr_matrix(
+                (dual_coef_data, dual_coef_indices, dual_coef_indptr),
+                (n_class, n_SV))
 
     def predict(self, X):
         """Perform regression on samples in X.
@@ -907,9 +910,10 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     bias = -1.0
     if fit_intercept:
         if intercept_scaling <= 0:
-            raise ValueError("Intercept scaling is %r but needs to be greater than 0."
-                             " To disable fitting an intercept,"
-                             " set fit_intercept=False." % intercept_scaling)
+            raise ValueError(
+                "Intercept scaling is %r but needs to be greater than 0."
+                " To disable fitting an intercept, set fit_intercept=False."
+                % intercept_scaling)
         else:
             bias = intercept_scaling
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -40,6 +40,34 @@ iris.target = iris.target[perm]
 iris.data = sparse.csr_matrix(iris.data)
 
 
+def test_sparse_svr_empty_support_vectors():
+    X = np.array([[0, 1, 0, 0],
+                  [0, 0, 0, 1],
+                  [0, 0, 1, 0],
+                  [0, 0, 0, 1]], dtype=np.float64)
+    y = np.array([0.04, 0.04, 0.10, 0.16], dtype=np.float64)
+    params = dict(kernel='linear', gamma=1.0, C=316.227766017, epsilon=0.1)
+
+    dense_model = svm.SVR(**params).fit(X, y)
+    assert dense_model.support_vectors_.shape == (0, X.shape[1])
+
+    X_sparse = sparse.csr_matrix(X)
+    sparse_model = svm.SVR(**params).fit(X_sparse, y)
+
+    assert sparse.isspmatrix_csr(sparse_model.support_vectors_)
+    assert sparse.isspmatrix_csr(sparse_model.dual_coef_)
+    assert sparse_model.support_vectors_.shape == (0, X.shape[1])
+    assert sparse_model.dual_coef_.shape == (1, 0)
+    assert sparse_model.dual_coef_.dtype == np.float64
+    assert sparse_model.support_.size == 0
+    assert sparse_model.dual_coef_.nnz == 0
+
+    assert_array_equal(sparse_model._n_support, dense_model._n_support)
+    assert_array_equal(sparse_model.support_, dense_model.support_)
+    assert_array_almost_equal(sparse_model.predict(X_sparse),
+                              dense_model.predict(X))
+
+
 def check_svm_model_equal(dense_svm, sparse_svm, X_train, y_train, X_test):
     dense_svm.fit(X_train.toarray(), y_train)
     if sparse.isspmatrix(X_test):
@@ -149,7 +177,7 @@ def test_svc_iris():
     for k in ('linear', 'poly', 'rbf'):
         sp_clf = svm.SVC(kernel=k).fit(iris.data, iris.target)
         clf = svm.SVC(kernel=k).fit(iris.data.toarray(),
-                                                   iris.target)
+                                    iris.target)
 
         assert_array_almost_equal(clf.support_vectors_,
                                   sp_clf.support_vectors_.toarray())


### PR DESCRIPTION
## Bug
`BaseLibSVM._sparse_fit` divides by `n_class` when building the CSR pointer array. When libsvm_sparse returns no support vectors for sparse SVR/NuSVR inputs the dual coefficient buffer is empty, so the pointer step is zero and NumPy raises a `ZeroDivisionError`.

Reference: #45

## Reproduction
1. Create the sparse dataset from the issue.
2. Fit `SVR(kernel='linear', gamma=1.0, C=316.227766017, epsilon=0.1)` on dense data (succeeds).
3. Fit the same estimator on the CSR copy of the data.

```pytb
Traceback (most recent call last):
  File "<stdin>", line 13, in <module>
  File "/workspace/scikit-learn/sklearn/svm/base.py", line 198, in fit
    fit(X, y, sample_weight, solver_type, kernel, random_seed=seed)
  File "/workspace/scikit-learn/sklearn/svm/base.py", line 291, in _sparse_fit
    dual_coef_indices.size / n_class)
ZeroDivisionError: float division by zero
```

## Fix
- guard `_sparse_fit` so we build an empty CSR dual coefficient matrix when no support vectors are returned
- add regression coverage that exercises sparse SVR with zero support vectors
- tidy a nearby long `ValueError` string to keep flake8 happy

## Tests
- Added `test_sparse_svr_empty_support_vectors`
- `pytest sklearn/svm/tests/test_sparse.py`
- `flake8 sklearn/svm/base.py sklearn/svm/tests/test_sparse.py`