### PR TITLE
swev-id: scikit-learn__scikit-learn-25232 add fill_value support to IterativeImputer

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -113,13 +113,16 @@ class IterativeImputer(_BaseImputer):
         number of features is huge. If `None`, all features will be used.
 
     initial_strategy : {'mean', 'median', 'most_frequent', 'constant'} or \
-            estimator with ``fit``, ``transform`` and ``get_params``, \
+            estimator with ``fit``, ``transform``, ``get_params`` and \
+            ``get_feature_names_out``, \
             default='mean'
         Strategy or imputer used to initialize the missing values. When a
         string is provided, it matches the `strategy` parameter of
         :class:`~sklearn.impute.SimpleImputer`. When an imputer instance is
-        provided, it is cloned and used for the initialization step. In this
-        case, :class:`~sklearn.impute.SimpleImputer`'s parameters such as
+        provided, it is cloned and used for the initialization step. The
+        instance must implement ``fit``, ``transform``, ``get_params`` and
+        ``get_feature_names_out``. In this case,
+        :class:`~sklearn.impute.SimpleImputer`'s parameters such as
         ``missing_values`` and ``keep_empty_features`` are synchronized when
         supported, and ``fill_value`` is ignored.
 
@@ -296,7 +299,12 @@ class IterativeImputer(_BaseImputer):
         "n_nearest_features": [None, Interval(Integral, 1, None, closed="left")],
         "initial_strategy": [
             StrOptions({"mean", "median", "most_frequent", "constant"}),
-            HasMethods(["fit", "transform", "get_params"]),
+            HasMethods([
+                "fit",
+                "transform",
+                "get_params",
+                "get_feature_names_out",
+            ]),
         ],
         "fill_value": "no_validation",
         "imputation_order": [

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -112,10 +112,24 @@ class IterativeImputer(_BaseImputer):
         imputed target feature. Can provide significant speed-up when the
         number of features is huge. If `None`, all features will be used.
 
-    initial_strategy : {'mean', 'median', 'most_frequent', 'constant'}, \
+    initial_strategy : {'mean', 'median', 'most_frequent', 'constant'} or \
+            estimator with ``fit``, ``transform`` and ``get_params``, \
             default='mean'
-        Which strategy to use to initialize the missing values. Same as the
-        `strategy` parameter in :class:`~sklearn.impute.SimpleImputer`.
+        Strategy or imputer used to initialize the missing values. When a
+        string is provided, it matches the `strategy` parameter of
+        :class:`~sklearn.impute.SimpleImputer`. When an imputer instance is
+        provided, it is cloned and used for the initialization step. In this
+        case, :class:`~sklearn.impute.SimpleImputer`'s parameters such as
+        ``missing_values`` and ``keep_empty_features`` are synchronized when
+        supported, and ``fill_value`` is ignored.
+
+    fill_value : object, default=None
+        When ``initial_strategy='constant'``, the value used to replace
+        missing values prior to the iterative imputation rounds. Mirrors the
+        ``fill_value`` parameter of :class:`~sklearn.impute.SimpleImputer`.
+        Either a scalar value or an array of shape ``(n_features,)`` can be
+        provided. ``np.nan`` is accepted. Ignored when ``initial_strategy`` is
+        an imputer instance.
 
     imputation_order : {'ascending', 'descending', 'roman', 'arabic', \
             'random'}, default='ascending'
@@ -181,8 +195,10 @@ class IterativeImputer(_BaseImputer):
 
     Attributes
     ----------
-    initial_imputer_ : object of type :class:`~sklearn.impute.SimpleImputer`
-        Imputer used to initialize the missing values.
+    initial_imputer_ : estimator
+        Imputer used to initialize the missing values. It is a
+        :class:`~sklearn.impute.SimpleImputer` when ``initial_strategy`` is a
+        string, otherwise it is a clone of the provided imputer instance.
 
     imputation_sequence_ : list of tuples
         Each tuple has `(feat_idx, neighbor_feat_idx, estimator)`, where
@@ -279,8 +295,10 @@ class IterativeImputer(_BaseImputer):
         "tol": [Interval(Real, 0, None, closed="left")],
         "n_nearest_features": [None, Interval(Integral, 1, None, closed="left")],
         "initial_strategy": [
-            StrOptions({"mean", "median", "most_frequent", "constant"})
+            StrOptions({"mean", "median", "most_frequent", "constant"}),
+            HasMethods(["fit", "transform", "get_params"]),
         ],
+        "fill_value": "no_validation",
         "imputation_order": [
             StrOptions({"ascending", "descending", "roman", "arabic", "random"})
         ],
@@ -301,6 +319,7 @@ class IterativeImputer(_BaseImputer):
         tol=1e-3,
         n_nearest_features=None,
         initial_strategy="mean",
+        fill_value=None,
         imputation_order="ascending",
         skip_complete=False,
         min_value=-np.inf,
@@ -322,6 +341,7 @@ class IterativeImputer(_BaseImputer):
         self.tol = tol
         self.n_nearest_features = n_nearest_features
         self.initial_strategy = initial_strategy
+        self.fill_value = fill_value
         self.imputation_order = imputation_order
         self.skip_complete = skip_complete
         self.min_value = min_value
@@ -610,11 +630,31 @@ class IterativeImputer(_BaseImputer):
         X_missing_mask = _get_mask(X, self.missing_values)
         mask_missing_values = X_missing_mask.copy()
         if self.initial_imputer_ is None:
-            self.initial_imputer_ = SimpleImputer(
-                missing_values=self.missing_values,
-                strategy=self.initial_strategy,
-                keep_empty_features=self.keep_empty_features,
-            )
+            if isinstance(self.initial_strategy, str):
+                self.initial_imputer_ = SimpleImputer(
+                    missing_values=self.missing_values,
+                    strategy=self.initial_strategy,
+                    fill_value=self.fill_value,
+                    keep_empty_features=self.keep_empty_features,
+                )
+            else:
+                self.initial_imputer_ = clone(self.initial_strategy)
+                init_params = self.initial_imputer_.get_params(deep=False)
+                params_to_set = {}
+                if "missing_values" in init_params:
+                    params_to_set["missing_values"] = self.missing_values
+                if "keep_empty_features" in init_params:
+                    params_to_set["keep_empty_features"] = (
+                        self.keep_empty_features
+                    )
+                if params_to_set:
+                    self.initial_imputer_.set_params(**params_to_set)
+                if self.fill_value is not None:
+                    warnings.warn(
+                        "'fill_value' is ignored when ``initial_strategy`` is set "
+                        "to an imputer instance.",
+                        UserWarning,
+                    )
             X_filled = self.initial_imputer_.fit_transform(X)
         else:
             X_filled = self.initial_imputer_.transform(X)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -12,6 +12,7 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_allclose_dense_sparse
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
+from sklearn.utils._param_validation import InvalidParameterError
 
 # make IterativeImputer available
 from sklearn.experimental import enable_iterative_imputer  # noqa
@@ -95,6 +96,17 @@ def test_imputation_shape(strategy):
     assert X_imputed.shape == (10, 2)
 
 
+class _MinimalImputer:
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X):
+        return X
+
+    def get_params(self, deep=True):
+        return {}
+
+
 @pytest.mark.parametrize("fill_value", [7, np.nan])
 def test_iterative_imputer_constant_strategy_respects_fill_value(fill_value):
     X = np.array([[np.nan, 1], [2, np.nan], [3, 4]], dtype=float)
@@ -153,6 +165,15 @@ def test_iterative_imputer_warns_when_fill_value_with_imputer_instance():
 
     with pytest.warns(UserWarning, match="'fill_value' is ignored"):
         imputer.fit_transform(X)
+
+
+def test_iterative_imputer_requires_feature_names_out():
+    X = np.array([[np.nan, 1], [2, np.nan]], dtype=float)
+
+    imputer = IterativeImputer(initial_strategy=_MinimalImputer(), max_iter=0)
+
+    with pytest.raises(InvalidParameterError):
+        imputer.fit(X)
 
 
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent"])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -16,6 +16,7 @@ from sklearn.utils._testing import assert_array_almost_equal
 # make IterativeImputer available
 from sklearn.experimental import enable_iterative_imputer  # noqa
 
+from sklearn.base import clone
 from sklearn.datasets import load_diabetes
 from sklearn.impute import MissingIndicator
 from sklearn.impute import SimpleImputer, IterativeImputer, KNNImputer
@@ -92,6 +93,66 @@ def test_imputation_shape(strategy):
     iterative_imputer = IterativeImputer(initial_strategy=strategy)
     X_imputed = iterative_imputer.fit_transform(X)
     assert X_imputed.shape == (10, 2)
+
+
+@pytest.mark.parametrize("fill_value", [7, np.nan])
+def test_iterative_imputer_constant_strategy_respects_fill_value(fill_value):
+    X = np.array([[np.nan, 1], [2, np.nan], [3, 4]], dtype=float)
+
+    expected = SimpleImputer(
+        strategy="constant", fill_value=fill_value
+    ).fit_transform(X)
+
+    imputer = IterativeImputer(
+        initial_strategy="constant", fill_value=fill_value, max_iter=0, random_state=0
+    )
+    transformed = imputer.fit_transform(X)
+
+    assert_allclose(transformed, expected, equal_nan=True)
+
+
+def test_iterative_imputer_constant_default_fill_value_matches_simple_imputer():
+    X = np.array([[np.nan, 1], [2, np.nan], [3, 4]], dtype=float)
+
+    expected = SimpleImputer(strategy="constant").fit_transform(X)
+
+    imputer = IterativeImputer(initial_strategy="constant", max_iter=0, random_state=0)
+    transformed = imputer.fit_transform(X)
+
+    assert_allclose(transformed, expected, equal_nan=True)
+
+
+def test_iterative_imputer_accepts_imputer_instance_for_initial_strategy():
+    X = np.array([[-1, 1, -1], [2, -1, 3], [-1, -1, -1]], dtype=float)
+
+    seed_imputer = SimpleImputer(strategy="most_frequent")
+    expected = clone(seed_imputer).set_params(
+        missing_values=-1, keep_empty_features=True
+    ).fit_transform(X)
+
+    imputer = IterativeImputer(
+        initial_strategy=seed_imputer,
+        max_iter=0,
+        missing_values=-1,
+        keep_empty_features=True,
+        random_state=0,
+    )
+
+    transformed = imputer.fit_transform(X)
+
+    assert_allclose(transformed, expected, equal_nan=True)
+
+
+def test_iterative_imputer_warns_when_fill_value_with_imputer_instance():
+    X = np.array([[np.nan, 1], [2, np.nan]], dtype=float)
+
+    seed_imputer = SimpleImputer(strategy="mean")
+    imputer = IterativeImputer(
+        initial_strategy=seed_imputer, fill_value=0, max_iter=0, random_state=0
+    )
+
+    with pytest.warns(UserWarning, match="'fill_value' is ignored"):
+        imputer.fit_transform(X)
 
 
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent"])


### PR DESCRIPTION
## Summary
- allow `IterativeImputer` to accept an imputer instance for `initial_strategy` and sync compatible parameters
- add the optional `fill_value` for constant initialization and document the behavior
- cover the new behavior with regression tests for strategy instances and fill values

## Testing
- LD_LIBRARY_PATH=/workspace/venv/lib/python3.11/site-packages/scikit_learn.libs:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib /workspace/venv/bin/pytest sklearn/impute/tests/test_impute.py -k "fill_value or imputer_instance"
- /workspace/venv/bin/flake8 sklearn/impute/_iterative.py sklearn/impute/tests/test_impute.py

## Failure Reproduction
```python
from sklearn.experimental import enable_iterative_imputer  # noqa
from sklearn.impute import IterativeImputer, SimpleImputer
import numpy as np

X = np.array([[np.nan, 1.], [2., 3.]])
IterativeImputer(
    initial_strategy=SimpleImputer(strategy='constant', fill_value=np.nan),
    max_iter=0,
).fit(X)
```

```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/workspace/venv/lib/python3.11/site-packages/sklearn/impute/_iterative.py", line 879, in fit
    self.fit_transform(X)
  File "/workspace/venv/lib/python3.11/site-packages/sklearn/utils/_set_output.py", line 157, in wrapped
    data_to_wrap = f(self, X, *args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/venv/lib/python3.11/site-packages/sklearn/base.py", line 1145, in wrapper
    estimator._validate_params()
  File "/workspace/venv/lib/python3.11/site-packages/sklearn/base.py", line 638, in _validate_params
    validate_parameter_constraints(
  File "/workspace/venv/lib/python3.11/site-packages/sklearn/utils/_param_validation.py", line 96, in validate_parameter_constraints
    raise InvalidParameterError(
sklearn.utils._param_validation.InvalidParameterError: The 'initial_strategy' parameter of IterativeImputer must be a str among {'median', 'mean', 'most_frequent', 'constant'}. Got SimpleImputer(fill_value=nan, strategy='constant') instead.
```

## Additional Notes
- Fixes #54
- Updated the class docstring to describe the new parameters
- Added targeted regression tests exercising the new initialization options
