### PR TITLE
Allow SFS to reuse iterable CV splits (swev-id: scikit-learn__scikit-learn-25973)

### DIFF
--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -8,12 +8,12 @@ import numpy as np
 import warnings
 
 from ._base import SelectorMixin
-from ..base import BaseEstimator, MetaEstimatorMixin, clone
+from ..base import BaseEstimator, MetaEstimatorMixin, clone, is_classifier
 from ..utils._param_validation import HasMethods, Hidden, Interval, StrOptions
 from ..utils._param_validation import RealNotInt
 from ..utils._tags import _safe_tags
 from ..utils.validation import check_is_fitted
-from ..model_selection import cross_val_score
+from ..model_selection import check_cv, cross_val_score
 from ..metrics import get_scorer_names
 
 
@@ -79,19 +79,23 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
 
         If None, the estimator's score method is used.
 
-    cv : int, cross-validation generator or an iterable, default=None
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
+    cv : int, cross-validation generator, or iterable, default=None
+        Determines the cross-validation splitting strategy. Possible inputs
+        for ``cv`` are:
 
-        - None, to use the default 5-fold cross validation,
+        - ``None``, to use the default 5-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
-        - An iterable yielding (train, test) splits as arrays of indices.
+        - an iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`KFold` is used. These splitters are instantiated
-        with `shuffle=False` so the splits will be the same across calls.
+        For integer/``None`` inputs, if the estimator is a classifier and ``y``
+        is either binary or multiclass, :class:`StratifiedKFold` is used. In
+        all other cases, :class:`KFold` is used. These splitters are
+        instantiated with ``shuffle=False`` so the splits will be the same
+        across calls.
+
+        Iterables, including generators, are materialized once for reuse. This
+        can increase memory consumption when the number of folds is large.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -273,9 +277,11 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
 
         old_score = -np.inf
         is_auto_select = self.tol is not None and self.n_features_to_select == "auto"
+        cv = check_cv(self.cv, y, classifier=is_classifier(self.estimator))
+
         for _ in range(n_iterations):
             new_feature_idx, new_score = self._get_best_new_feature_score(
-                cloned_estimator, X, y, current_mask
+                cloned_estimator, X, y, current_mask, cv
             )
             if is_auto_select and ((new_score - old_score) < self.tol):
                 break
@@ -291,7 +297,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
 
         return self
 
-    def _get_best_new_feature_score(self, estimator, X, y, current_mask):
+    def _get_best_new_feature_score(self, estimator, X, y, current_mask, cv):
         # Return the best new feature and its score to add to the current_mask,
         # i.e. return the best new feature and its score to add (resp. remove)
         # when doing forward selection (resp. backward selection).
@@ -309,7 +315,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
                 estimator,
                 X_new,
                 y,
-                cv=self.cv,
+                cv=cv,
                 scoring=self.scoring,
                 n_jobs=self.n_jobs,
             ).mean()

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -6,11 +6,12 @@ from numpy.testing import assert_array_equal
 from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SequentialFeatureSelector
-from sklearn.datasets import make_regression, make_blobs
+from sklearn.datasets import make_blobs, make_classification, make_regression
 from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import HistGradientBoostingRegressor
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import LeaveOneGroupOut, cross_val_score
 from sklearn.cluster import KMeans
+from sklearn.neighbors import KNeighborsClassifier
 
 
 def test_bad_n_features_to_select():
@@ -314,3 +315,37 @@ def test_backward_neg_tol():
 
     assert 0 < sfs.get_support().sum() < X.shape[1]
     assert new_score < initial_score
+
+
+def test_sfs_supports_iterable_cv_generator():
+    X, y = make_classification(n_samples=40, n_features=8, random_state=0)
+
+    groups = np.zeros_like(y, dtype=int)
+    groups[y.size // 2 :] = 1
+
+    logo = LeaveOneGroupOut()
+    cv = logo.split(X, y, groups=groups)
+
+    selector = SequentialFeatureSelector(
+        KNeighborsClassifier(n_neighbors=3),
+        n_features_to_select=3,
+        scoring="accuracy",
+        cv=cv,
+    )
+
+    selector.fit(X, y)
+
+    assert selector.get_support().sum() == 3
+
+
+def test_sfs_baseline_cv_int_runs():
+    X, y = make_regression(n_samples=60, n_features=10, random_state=0)
+
+    selector = SequentialFeatureSelector(
+        LinearRegression(), n_features_to_select=4, cv=5
+    )
+
+    selector.fit(X, y)
+
+    assert selector.get_support().sum() == 4
+    assert selector.transform(X).shape[1] == 4


### PR DESCRIPTION
## Summary
- normalize `SequentialFeatureSelector` CV handling with `check_cv` so iterable/generator inputs are reused safely
- document that iterables are materialized once and extend tests to cover generator and integer CV inputs

Resolves #55.

## Reproduction (pre-fix)
```python
from sklearn.datasets import make_classification
from sklearn.feature_selection import SequentialFeatureSelector
from sklearn.neighbors import KNeighborsClassifier
from sklearn.model_selection import LeaveOneGroupOut
import numpy as np

X, y = make_classification(random_state=0)

groups = np.zeros_like(y, dtype=int)
groups[y.size//2:] = 1

cv = LeaveOneGroupOut()
splits = cv.split(X, y, groups=groups)

clf = KNeighborsClassifier(n_neighbors=5)
seq = SequentialFeatureSelector(clf, n_features_to_select=5, scoring='accuracy', cv=splits)
seq.fit(X, y)
```

```
IndexError: list index out of range
```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/y6zrr7dfg051mz4dpjvaldy4g9cy6wmq-lapack-3/lib nix shell nixpkgs#python310 nixpkgs#python310Packages.pip --command python3.10 - <<'PY'
import importlib.machinery
import importlib.util
import sys
from pathlib import Path

import pytest
import sklearn
import sklearn.feature_selection

name = "sklearn.feature_selection._sequential"
path = Path("/workspace/scikit-learn/sklearn/feature_selection/_sequential.py")
loader = importlib.machinery.SourceFileLoader(name, str(path))
spec = importlib.util.spec_from_loader(name, loader)
module = importlib.util.module_from_spec(spec)
loader.exec_module(module)
sys.modules[name] = module
sklearn.feature_selection._sequential = module
sklearn.feature_selection.SequentialFeatureSelector = module.SequentialFeatureSelector

sys.exit(
    pytest.main(
        [
            "--import-mode=importlib",
            "scikit-learn/sklearn/feature_selection/tests/test_sequential.py::test_sfs_supports_iterable_cv_generator",
            "scikit-learn/sklearn/feature_selection/tests/test_sequential.py::test_sfs_baseline_cv_int_runs",
        ]
    )
)
PY`
- `nix shell nixpkgs#python310 nixpkgs#python310Packages.pip --command flake8 sklearn/feature_selection/_sequential.py sklearn/feature_selection/tests/test_sequential.py`