### PR TITLE
feat: add preserve_output_dtypes config [noa/issue-52] swev-id: scikit-learn__scikit-learn-25102

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -15,6 +15,7 @@ _global_config = {
     "enable_cython_pairwise_dist": True,
     "array_api_dispatch": False,
     "transform_output": "default",
+    "preserve_output_dtypes": False,
 }
 _threadlocal = threading.local()
 
@@ -54,6 +55,7 @@ def set_config(
     enable_cython_pairwise_dist=None,
     array_api_dispatch=None,
     transform_output=None,
+    preserve_output_dtypes=None,
 ):
     """Set global scikit-learn configuration
 
@@ -134,6 +136,11 @@ def set_config(
 
         .. versionadded:: 1.2
 
+    preserve_output_dtypes : bool, default=None
+        Preserve input pandas dtypes when ``transform_output="pandas"`` and
+        transformers emit an unmodified subset or reordering of the input
+        columns. Global default: False.
+
     See Also
     --------
     config_context : Context manager for global scikit-learn configuration.
@@ -157,6 +164,8 @@ def set_config(
         local_config["array_api_dispatch"] = array_api_dispatch
     if transform_output is not None:
         local_config["transform_output"] = transform_output
+    if preserve_output_dtypes is not None:
+        local_config["preserve_output_dtypes"] = preserve_output_dtypes
 
 
 @contextmanager
@@ -170,6 +179,7 @@ def config_context(
     enable_cython_pairwise_dist=None,
     array_api_dispatch=None,
     transform_output=None,
+    preserve_output_dtypes=None,
 ):
     """Context manager for global scikit-learn configuration.
 
@@ -249,6 +259,12 @@ def config_context(
 
         .. versionadded:: 1.2
 
+    preserve_output_dtypes : bool, default=None
+        Preserve input pandas dtypes when ``transform_output="pandas"`` and
+        transformers emit an unmodified subset or reordering of the input
+        columns. If None, the existing value won't change. The default value
+        is False.
+
     Yields
     ------
     None.
@@ -286,6 +302,7 @@ def config_context(
         enable_cython_pairwise_dist=enable_cython_pairwise_dist,
         array_api_dispatch=array_api_dispatch,
         transform_output=transform_output,
+        preserve_output_dtypes=preserve_output_dtypes,
     )
 
     try:

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -82,7 +82,13 @@ def _wrap_in_pandas_container(
 
             if all(col in original_input.columns for col in resolved_columns):
                 original_subset = original_input.loc[:, resolved_columns]
-                if np.array_equal(df.to_numpy(), original_subset.to_numpy()):
+                left = df.to_numpy(dtype=object, na_value=np.nan)
+                right = original_subset.to_numpy(dtype=object, na_value=np.nan)
+                left_isna = pd.isna(left)
+                right_isna = pd.isna(right)
+                if np.array_equal(left_isna, right_isna) and np.array_equal(
+                    left[~left_isna], right[~left_isna]
+                ):
                     df = original_subset.copy()
                     df.columns = resolved_columns
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -376,3 +376,28 @@ def test_preserve_dtypes_with_duplicate_columns():
     pd.testing.assert_series_equal(
         X_selected.dtypes, X.dtypes, check_names=False
     )
+
+
+def test_preserve_dtypes_with_nans():
+    pd = pytest.importorskip("pandas")
+
+    X = pd.DataFrame(
+        {
+            "float_nan": pd.Series([1.0, np.nan, 3.0], dtype="Float32"),
+            "int_nan": pd.Series([1, None, 3], dtype="Int64"),
+            "extra": pd.Series([0.5, 0.6, 0.7], dtype=np.float64),
+        }
+    )
+
+    selector = DuplicateSelector(["float_nan", "int_nan"]).set_output(
+        transform="pandas"
+    )
+
+    with config_context(transform_output="pandas", preserve_output_dtypes=True):
+        X_selected = selector.fit(X).transform(X)
+
+    expected = X[["float_nan", "int_nan"]]
+    pd.testing.assert_series_equal(
+        X_selected.dtypes, expected.dtypes, check_names=False
+    )
+    pd.testing.assert_frame_equal(X_selected, expected)


### PR DESCRIPTION
## Summary
- add preserve_output_dtypes to global config and wrappers
- ensure pandas outputs can retain input dtypes when untouched
- cover dtype preservation, skip scenarios, and duplicate column handling

## Testing
- pytest sklearn/utils/tests/test_set_output.py -q

## Issues
- #52