### PR TITLE
fix: correct repr for RepeatedKFold and RepeatedStratifiedKFold (swev-id: scikit-learn__scikit-learn-14983)

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1163,6 +1163,9 @@ class _RepeatedSplits(metaclass=ABCMeta):
                      **self.cvargs)
         return cv.get_n_splits(X, y, groups) * self.n_repeats
 
+    def __repr__(self):
+        return _build_repr(self)
+
 
 class RepeatedKFold(_RepeatedSplits):
     """Repeated K-Fold cross validator.

--- a/sklearn/model_selection/tests/test_repeated_split_repr.py
+++ b/sklearn/model_selection/tests/test_repeated_split_repr.py
@@ -1,0 +1,37 @@
+from sklearn import config_context
+from sklearn.model_selection import (
+    RepeatedKFold,
+    RepeatedStratifiedKFold,
+)
+
+
+def test_repeated_kfold_repr_default():
+    with config_context(print_changed_only=False):
+        assert (
+            repr(RepeatedKFold())
+            == "RepeatedKFold(n_splits=5, n_repeats=10, random_state=None)"
+        )
+
+
+def test_repeated_stratified_kfold_repr_default():
+    with config_context(print_changed_only=False):
+        assert (
+            repr(RepeatedStratifiedKFold())
+            == "RepeatedStratifiedKFold(n_splits=5, n_repeats=10, random_state=None)"
+        )
+
+
+def test_repeated_kfold_repr_nondefault():
+    with config_context(print_changed_only=False):
+        assert (
+            repr(RepeatedKFold(n_splits=3, n_repeats=2, random_state=42))
+            == "RepeatedKFold(n_splits=3, n_repeats=2, random_state=42)"
+        )
+
+
+def test_repeated_stratified_kfold_repr_nondefault():
+    with config_context(print_changed_only=False):
+        assert (
+            repr(RepeatedStratifiedKFold(n_splits=4, n_repeats=3, random_state=0))
+            == "RepeatedStratifiedKFold(n_splits=4, n_repeats=3, random_state=0)"
+        )


### PR DESCRIPTION
Summary
- Add __repr__ to _RepeatedSplits to use the existing _build_repr helper, ensuring proper repr for RepeatedKFold and RepeatedStratifiedKFold.
- Add regression tests for default and non-default parameter combinations.

Linked Issue
- See Issue: https://github.com/agyn-sandbox/scikit-learn/issues/67

Reproduction Steps
1) In Python, run:
```python
from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
repr(RepeatedKFold())
repr(RepeatedStratifiedKFold())
```
2) Before this fix, repr(...) returns the default object address strings.
3) After this fix, expected outputs:
```
RepeatedKFold(n_splits=5, n_repeats=10, random_state=None)
RepeatedStratifiedKFold(n_splits=5, n_repeats=10, random_state=None)
```

Observed failure and stack trace (pre-fix)
- Attempting to import and run from the source tree without building yields the following (when using the unbuilt source):
```
ImportError: No module named 'sklearn.__check_build._check_build'
It seems that scikit-learn has not been built correctly.
```
- The functional failure targeted by this PR is the incorrect repr of the repeated splitters, which manifests as object address strings rather than parameterized reprs.

Notes
- No CI run triggered manually per policy.
- Base branch: scikit-learn__scikit-learn-14983.