### PR TITLE
Fix strip_accents_unicode for NFKD inputs (swev-id: scikit-learn__scikit-learn-15100)

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Mapping
 import re
+import unicodedata
 import warnings
 
 import pytest
@@ -96,6 +97,20 @@ def test_strip_accents():
     a = "this is à test"
     expected = 'this is a test'
     assert strip_accents_unicode(a) == expected
+
+
+def test_strip_accents_unicode_nfkd_inputs():
+    assert strip_accents_unicode('ñ') == 'n'
+    assert strip_accents_unicode('n' + '\u0303') == 'n'
+
+    assert strip_accents_unicode('e' + '\u0301' + '\u0308') == 'e'
+
+    pre_normalized = unicodedata.normalize('NFKD', 'é')
+    assert strip_accents_unicode(pre_normalized) == 'e'
+
+    mixed = '\u0625' + 'ñ' + '\uFF21'
+    expected = '\u0627' + 'n' + 'A'
+    assert strip_accents_unicode(mixed) == expected
 
 
 def test_to_ascii():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -130,10 +130,7 @@ def strip_accents_unicode(s):
         ASCII equivalent.
     """
     normalized = unicodedata.normalize('NFKD', s)
-    if normalized == s:
-        return s
-    else:
-        return ''.join([c for c in normalized if not unicodedata.combining(c)])
+    return ''.join([c for c in normalized if not unicodedata.combining(c)])
 
 
 def strip_accents_ascii(s):


### PR DESCRIPTION
## Related Issue
- #65

## Reproduction Steps
1. Activate the project environment (`source /workspace/sklearn-py37/bin/activate`).
2. Export the runtime libraries:
   `export LD_LIBRARY_PATH=/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib:/nix/store/y1bnyxikip76b1nk1adjabnx67pwkl36-libxcrypt-4.5.2/lib:/workspace/miniconda3/lib:$HOME/.nix-profile/lib:$LD_LIBRARY_PATH`.
3. Run `pytest -q sklearn/feature_extraction/tests/test_text.py -k nfkd --maxfail=1 -vv`.

## Observed Failure (pre-fix)
```
============================= test session starts ==============================
platform linux -- Python 3.7.10, pytest-5.4.3, py-1.11.0, pluggy-0.13.1 -- /workspace/sklearn-py37/bin/python
cachedir: .pytest_cache
rootdir: /workspace/scikit-learn, inifile: setup.cfg
collecting ... collected 112 items / 111 deselected / 1 selected

sklearn/feature_extraction/tests/test_text.py::test_strip_accents_unicode_nfkd_inputs FAILED [100%]

=================================== FAILURES ===================================
____________________ test_strip_accents_unicode_nfkd_inputs ____________________

    def test_strip_accents_unicode_nfkd_inputs():
        assert strip_accents_unicode('ñ') == 'n'
>       assert strip_accents_unicode('n' + '\\u0303') == 'n'
E       AssertionError: assert 'ñ' == 'n'
E         - n
E         + ñ

sklearn/feature_extraction/tests/test_text.py:104: AssertionError
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
====================== 1 failed, 111 deselected in 0.18s =======================
```

## Fix Summary
- Always drop combining characters after NFKD normalization in `strip_accents_unicode` so pre-normalized inputs cannot skip accent stripping.
- Add regression coverage for composed, decomposed, multi-mark, and mixed-script inputs to lock in the intended behavior.

## Tests Added
- `test_strip_accents_unicode_nfkd_inputs` validating composed vs decomposed strings, stacked combining marks, pre-normalized inputs, and mixed-script inputs.

## Verification
- `pytest -q sklearn/feature_extraction/tests/test_text.py -k strip_accents`
- `flake8 sklearn/feature_extraction/text.py sklearn/feature_extraction/tests/test_text.py`